### PR TITLE
ci: replace classic pat with github app token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,14 @@ jobs:
     name: Release Please
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
       - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
         with:
-          token: ${{ secrets.WORKFLOW_TOKEN }} # PAT so the tag push can trigger publish.yml
+          token: ${{ steps.app-token.outputs.token }} # App token so the tag/release created by release-please can trigger other workflows
 


### PR DESCRIPTION
Part of https://github.com/bucketeer-io/bucketeer/issues/2703

Replaces the classic PATs (WORKFLOW_TOKEN, REPO_ACCESS_PAT) with short-lived installation tokens minted from a GitHub App via actions/create-github-app-token, as part of removing classic PATs from CI. The app token still allows the tag/release created by release-please to trigger the publish workflows.