### PR TITLE
ci: build android demo app before booting the emulator in e2e

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -150,7 +150,7 @@ jobs:
         id: gradle
         continue-on-error: true
         with:
-          gradle-home-cache-cleanup: true
+          cache-cleanup: on-success
           cache-read-only: false
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2  # Reduce timeout from default 5 minutes
@@ -161,7 +161,6 @@ jobs:
         if: steps.gradle.outcome == 'failure'
         uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
         with:
-          gradle-home-cache-cleanup: true
           cache-read-only: false
           cache-disabled: true  # Disable cache on retry to avoid timeout
 
@@ -203,6 +202,17 @@ jobs:
           echo "EXPO_PUBLIC_BKT_API_KEY=${{ secrets.E2E_API_KEY }}" >> demo/expo_react_${{ matrix.react-version }}/.env
           echo "CI=true" >> demo/expo_react_${{ matrix.react-version }}/.env
 
+      # Build the APK before booting the emulator so Gradle gets the full CPU.
+      # The maestro flow launches the app itself (launchApp), so the emulator
+      # step below only needs the APK installed, not `expo run:android`.
+      - name: Build demo app for Android (React ${{ matrix.react-version }})
+        env:
+          # Optimized Gradle options for CI
+          GRADLE_OPTS: -Dorg.gradle.daemon=true -Dorg.gradle.parallel=true -Dorg.gradle.caching=true -Dorg.gradle.jvmargs="-Xmx2g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError"
+        run: |
+          cd demo/expo_react_${{ matrix.react-version }}/android
+          ./gradlew assembleRelease --stacktrace --build-cache
+
       - name: Setup Maestro
         uses: dniHze/maestro-test-action@v1
         with:
@@ -213,9 +223,6 @@ jobs:
           cp e2e/react_versions/react_${{ matrix.react-version }}.yml e2e/react_version.yml
 
       - name: Run Android integration tests (React ${{ matrix.react-version }})
-        env:
-          # Optimized Gradle options for CI
-          GRADLE_OPTS: -Dorg.gradle.daemon=true -Dorg.gradle.parallel=true -Dorg.gradle.caching=true -Dorg.gradle.jvmargs="-Xmx2g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError"
         uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed # v2.34.0
         with:
           api-level: ${{ matrix.api-level }}
@@ -225,8 +232,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -memory 2048
           disable-animations: true
-          # Run tests with sharding
-          script: yarn build:e2e:android:react${{ matrix.react-version }} && maestro test e2e --format=junit --output=report.xml --no-ansi
+          script: adb install -r demo/expo_react_${{ matrix.react-version }}/android/app/build/outputs/apk/release/app-release.apk && maestro test e2e --format=junit --output=report.xml --no-ansi
 
       - name: Upload Android E2E test results (React ${{ matrix.react-version }})
         uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,16 +28,40 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Injected before the app cache lookup so the cache key includes the
+      # .env contents: rotating the e2e key/endpoint invalidates the cache.
+      - name: Inject environment variables
+        run: |
+          rm -f demo/expo_react_${{ matrix.react-version }}/.env
+          echo "EXPO_PUBLIC_BKT_API_ENDPOINT=${{ secrets.E2E_API_ENDPOINT }}" >> demo/expo_react_${{ matrix.react-version }}/.env
+          echo "EXPO_PUBLIC_BKT_API_KEY=${{ secrets.E2E_API_KEY }}" >> demo/expo_react_${{ matrix.react-version }}/.env
+          echo "CI=true" >> demo/expo_react_${{ matrix.react-version }}/.env
+
+      # Reuse the built demo app when nothing that affects it has changed
+      # (typical for e2e runs triggered by backend deployments). On a cache
+      # hit the whole build chain below is skipped.
+      - name: Restore demo app cache
+        id: app-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: demo/expo_react_${{ matrix.react-version }}/ios/build/Build/Products/Release-iphonesimulator/*.app
+          key: demo-app-ios-react${{ matrix.react-version }}-${{ hashFiles('src/**', 'package.json', 'yarn.lock', format('demo/expo_react_{0}/**', matrix.react-version), format('!demo/expo_react_{0}/node_modules/**', matrix.react-version), format('!demo/expo_react_{0}/android/**', matrix.react-version), format('!demo/expo_react_{0}/ios/**', matrix.react-version), format('demo/expo_react_{0}/.env', matrix.react-version)) }}-v1
+
       - name: Setup
+        if: steps.app-cache.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup
 
       - name: Build package
+        if: steps.app-cache.outputs.cache-hit != 'true'
         run: |
           yarn build
 
+      # --no-install: node modules are already installed by Setup, and pods
+      # are installed by the dedicated step below (avoids a duplicate pod install)
       - name: Prepare Expo prebuild for the demo app - React ${{ matrix.react-version }}
+        if: steps.app-cache.outputs.cache-hit != 'true'
         run: |
-          yarn demo/expo_react_${{ matrix.react-version }} prebuild
+          yarn demo/expo_react_${{ matrix.react-version }} prebuild --no-install
 
       - name: Select Xcode version
         run: sudo xcode-select -s '/Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer'
@@ -49,6 +73,7 @@ jobs:
           sleep 10
 
       - name: Restore CocoaPods cache
+        if: steps.app-cache.outputs.cache-hit != 'true'
         id: cocoapods-cache
         uses: actions/cache/restore@v4
         with:
@@ -61,35 +86,49 @@ jobs:
             ${{ runner.os }}-pods-react${{ matrix.react-version }}-
 
       - name: Install CocoaPods dependencies
+        if: steps.app-cache.outputs.cache-hit != 'true'
         run: |
           cd demo/expo_react_${{ matrix.react-version }}/ios
           pod install
           cd ../..
-          
+
       - uses: irgaly/xcode-cache@v1
+        if: steps.app-cache.outputs.cache-hit != 'true'
         with:
           key: xcode-cache-deriveddata-${{ github.workflow }}-react${{ matrix.react-version }}-${{ github.sha }}
           restore-keys: xcode-cache-deriveddata-${{ github.workflow }}-react${{ matrix.react-version }}-
 
-      - name: Inject environment variables
-        run: |
-          rm -f demo/expo_react_${{ matrix.react-version }}/.env
-          echo "EXPO_PUBLIC_BKT_API_ENDPOINT=${{ secrets.E2E_API_ENDPOINT }}" >> demo/expo_react_${{ matrix.react-version }}/.env
-          echo "EXPO_PUBLIC_BKT_API_KEY=${{ secrets.E2E_API_KEY }}" >> demo/expo_react_${{ matrix.react-version }}/.env
-          echo "CI=true" >> demo/expo_react_${{ matrix.react-version }}/.env
-
       - name: Build demo app for iOS (React ${{ matrix.react-version }})
+        if: steps.app-cache.outputs.cache-hit != 'true'
         run: |
           yarn build:e2e:ios:react${{ matrix.react-version }}
 
       - name: Cache cocoapods dependencies
-        if: steps.cocoapods-cache.outputs.cache-hit != 'true'
+        if: steps.app-cache.outputs.cache-hit != 'true' && steps.cocoapods-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: |
             demo/expo_react_${{ matrix.react-version }}/ios/Pods
             demo/expo_react_${{ matrix.react-version }}/ios/Podfile.lock
           key: ${{ steps.cocoapods-cache.outputs.cache-primary-key }}
+
+      - name: Save demo app cache
+        if: steps.app-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: demo/expo_react_${{ matrix.react-version }}/ios/build/Build/Products/Release-iphonesimulator/*.app
+          key: ${{ steps.app-cache.outputs.cache-primary-key }}
+
+      # Needed on the cache-hit path (no build ran); harmless re-install otherwise.
+      - name: Install demo app to simulator
+        run: |
+          APP_PATH=$(find demo/expo_react_${{ matrix.react-version }}/ios/build/Build/Products/Release-iphonesimulator -maxdepth 1 -name "*.app" -type d | head -n 1)
+          if [ -z "$APP_PATH" ]; then
+            echo "No .app bundle found" >&2
+            exit 1
+          fi
+          echo "Installing $APP_PATH"
+          xcrun simctl install ${{ env.IOS_DEVICE_ID }} "$APP_PATH"
 
       - name: Copy E2E test file for React ${{ matrix.react-version }}
         run: |
@@ -128,24 +167,49 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Injected before the APK cache lookup so the cache key includes the
+      # .env contents: rotating the e2e key/endpoint invalidates the cache.
+      - name: Inject environment variables
+        run: |
+          rm -f demo/expo_react_${{ matrix.react-version }}/.env
+          echo "EXPO_PUBLIC_BKT_API_ENDPOINT=${{ secrets.E2E_API_ENDPOINT }}" >> demo/expo_react_${{ matrix.react-version }}/.env
+          echo "EXPO_PUBLIC_BKT_API_KEY=${{ secrets.E2E_API_KEY }}" >> demo/expo_react_${{ matrix.react-version }}/.env
+          echo "CI=true" >> demo/expo_react_${{ matrix.react-version }}/.env
+
+      # Reuse the built APK when nothing that affects it has changed
+      # (typical for e2e runs triggered by backend deployments). On a cache
+      # hit the whole build chain below is skipped.
+      - name: Restore demo APK cache
+        id: apk-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: demo/expo_react_${{ matrix.react-version }}/android/app/build/outputs/apk/release/app-release.apk
+          key: demo-app-android-react${{ matrix.react-version }}-${{ hashFiles('src/**', 'package.json', 'yarn.lock', format('demo/expo_react_{0}/**', matrix.react-version), format('!demo/expo_react_{0}/node_modules/**', matrix.react-version), format('!demo/expo_react_{0}/android/**', matrix.react-version), format('!demo/expo_react_{0}/ios/**', matrix.react-version), format('demo/expo_react_{0}/.env', matrix.react-version)) }}-v1
+
       - name: Setup
+        if: steps.apk-cache.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup
 
       - name: Build package
+        if: steps.apk-cache.outputs.cache-hit != 'true'
         run: |
           yarn build
 
+      # --no-install: node modules are already installed by Setup
       - name: Prepare Expo prebuild for the demo app - React ${{ matrix.react-version }}
+        if: steps.apk-cache.outputs.cache-hit != 'true'
         run: |
-          yarn demo/expo_react_${{ matrix.react-version }} prebuild
+          yarn demo/expo_react_${{ matrix.react-version }} prebuild --no-install
 
       - name: Set up JDK 17
+        if: steps.apk-cache.outputs.cache-hit != 'true'
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: "temurin"
           java-version: 17
 
       - name: Setup gradle
+        if: steps.apk-cache.outputs.cache-hit != 'true'
         uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
         id: gradle
         continue-on-error: true
@@ -158,11 +222,30 @@ jobs:
 
       # Retry gradle setup if it failed (usually due to cache timeout)
       - name: Retry Setup gradle
-        if: steps.gradle.outcome == 'failure'
+        if: steps.apk-cache.outputs.cache-hit != 'true' && steps.gradle.outcome == 'failure'
         uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
         with:
           cache-read-only: false
           cache-disabled: true  # Disable cache on retry to avoid timeout
+
+      # Build the APK before booting the emulator so Gradle gets the full CPU.
+      # The maestro flow launches the app itself (launchApp), so the emulator
+      # step below only needs the APK installed, not `expo run:android`.
+      - name: Build demo app for Android (React ${{ matrix.react-version }})
+        if: steps.apk-cache.outputs.cache-hit != 'true'
+        env:
+          # Optimized Gradle options for CI
+          GRADLE_OPTS: -Dorg.gradle.daemon=true -Dorg.gradle.parallel=true -Dorg.gradle.caching=true -Dorg.gradle.jvmargs="-Xmx2g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError"
+        run: |
+          cd demo/expo_react_${{ matrix.react-version }}/android
+          ./gradlew assembleRelease --stacktrace --build-cache
+
+      - name: Save demo APK cache
+        if: steps.apk-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: demo/expo_react_${{ matrix.react-version }}/android/app/build/outputs/apk/release/app-release.apk
+          key: ${{ steps.apk-cache.outputs.cache-primary-key }}
 
       - name: AVD cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
@@ -194,24 +277,6 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -memory 2048 -no-snapshot-load
           disable-animations: true
           script: echo "Generated AVD snapshot for caching"
-
-      - name: Inject environment variables
-        run: |
-          rm -f demo/expo_react_${{ matrix.react-version }}/.env
-          echo "EXPO_PUBLIC_BKT_API_ENDPOINT=${{ secrets.E2E_API_ENDPOINT }}" >> demo/expo_react_${{ matrix.react-version }}/.env
-          echo "EXPO_PUBLIC_BKT_API_KEY=${{ secrets.E2E_API_KEY }}" >> demo/expo_react_${{ matrix.react-version }}/.env
-          echo "CI=true" >> demo/expo_react_${{ matrix.react-version }}/.env
-
-      # Build the APK before booting the emulator so Gradle gets the full CPU.
-      # The maestro flow launches the app itself (launchApp), so the emulator
-      # step below only needs the APK installed, not `expo run:android`.
-      - name: Build demo app for Android (React ${{ matrix.react-version }})
-        env:
-          # Optimized Gradle options for CI
-          GRADLE_OPTS: -Dorg.gradle.daemon=true -Dorg.gradle.parallel=true -Dorg.gradle.caching=true -Dorg.gradle.jvmargs="-Xmx2g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError"
-        run: |
-          cd demo/expo_react_${{ matrix.react-version }}/android
-          ./gradlew assembleRelease --stacktrace --build-cache
 
       - name: Setup Maestro
         uses: dniHze/maestro-test-action@v1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -69,8 +69,22 @@ jobs:
       - name: Boot iPhone Simulator
         run: |
           xcrun simctl list devices available
-          xcrun simctl boot ${{ env.IOS_DEVICE_ID }} || echo "Simulator may already be booted"
-          sleep 10
+          # Use the pinned device if it exists on this runner image; otherwise
+          # fall back to any available iPhone on an iOS 18 runtime
+          # (maestro does not work with iOS 26 simulators yet).
+          DEVICE_ID="${{ env.IOS_DEVICE_ID }}"
+          if ! xcrun simctl list devices available | grep -q "$DEVICE_ID"; then
+            echo "Pinned simulator $DEVICE_ID not found, selecting an available iOS 18 iPhone"
+            DEVICE_ID=$(xcrun simctl list -j devices available | jq -r '.devices | to_entries[] | select(.key | contains("iOS-18")) | .value[] | select(.name | startswith("iPhone")) | .udid' | head -n 1)
+          fi
+          if [ -z "$DEVICE_ID" ]; then
+            echo "No suitable iPhone simulator found" >&2
+            exit 1
+          fi
+          echo "Booting simulator $DEVICE_ID"
+          xcrun simctl boot "$DEVICE_ID" || true
+          # Wait until the device is fully booted; fails loudly if it cannot boot
+          xcrun simctl bootstatus "$DEVICE_ID" -b
 
       - name: Restore CocoaPods cache
         if: steps.app-cache.outputs.cache-hit != 'true'
@@ -142,7 +156,8 @@ jobs:
             exit 1
           fi
           echo "Installing $APP_PATH"
-          xcrun simctl install ${{ env.IOS_DEVICE_ID }} "$APP_PATH"
+          # Install to the booted simulator (expo run:ios and maestro target it too)
+          xcrun simctl install booted "$APP_PATH"
 
       - name: Copy E2E test file for React ${{ matrix.react-version }}
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,7 +44,7 @@ jobs:
         id: app-cache
         uses: actions/cache/restore@v4
         with:
-          path: demo/expo_react_${{ matrix.react-version }}/ios/build/Build/Products/Release-iphonesimulator/*.app
+          path: build-artifacts/ios-react${{ matrix.react-version }}
           key: demo-app-ios-react${{ matrix.react-version }}-${{ hashFiles('src/**', 'package.json', 'yarn.lock', format('demo/expo_react_{0}/**', matrix.react-version), format('!demo/expo_react_{0}/node_modules/**', matrix.react-version), format('!demo/expo_react_{0}/android/**', matrix.react-version), format('!demo/expo_react_{0}/ios/**', matrix.react-version), format('demo/expo_react_{0}/.env', matrix.react-version)) }}-v1
 
       - name: Setup
@@ -103,6 +103,20 @@ jobs:
         run: |
           yarn build:e2e:ios:react${{ matrix.react-version }}
 
+      # expo run:ios builds into the default Xcode DerivedData location;
+      # copy the .app to a stable path so it can be cached and installed from there
+      - name: Stage built demo app
+        if: steps.app-cache.outputs.cache-hit != 'true'
+        run: |
+          APP_PATH=$(find ~/Library/Developer/Xcode/DerivedData -type d -name "*.app" -path "*Release-iphonesimulator*" -print0 | xargs -0 ls -td 2>/dev/null | head -n 1)
+          if [ -z "$APP_PATH" ]; then
+            echo "No .app bundle found in DerivedData" >&2
+            exit 1
+          fi
+          echo "Staging $APP_PATH"
+          mkdir -p build-artifacts/ios-react${{ matrix.react-version }}
+          cp -R "$APP_PATH" build-artifacts/ios-react${{ matrix.react-version }}/
+
       - name: Cache cocoapods dependencies
         if: steps.app-cache.outputs.cache-hit != 'true' && steps.cocoapods-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
@@ -116,13 +130,13 @@ jobs:
         if: steps.app-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: demo/expo_react_${{ matrix.react-version }}/ios/build/Build/Products/Release-iphonesimulator/*.app
+          path: build-artifacts/ios-react${{ matrix.react-version }}
           key: ${{ steps.app-cache.outputs.cache-primary-key }}
 
       # Needed on the cache-hit path (no build ran); harmless re-install otherwise.
       - name: Install demo app to simulator
         run: |
-          APP_PATH=$(find demo/expo_react_${{ matrix.react-version }}/ios/build/Build/Products/Release-iphonesimulator -maxdepth 1 -name "*.app" -type d | head -n 1)
+          APP_PATH=$(find build-artifacts/ios-react${{ matrix.react-version }} -maxdepth 1 -name "*.app" -type d | head -n 1)
           if [ -z "$APP_PATH" ]; then
             echo "No .app bundle found" >&2
             exit 1


### PR DESCRIPTION
## Summary

Analysis of the [latest e2e run](https://github.com/bucketeer-io/react-native-client-sdk/actions/runs/30076414284) (Android 13-14 min, iOS 7-12 min) showed two distinct issues:

### 1. All caches are always cold (no code change needed)

The workflow already has correct caching (Gradle, AVD snapshot, CocoaPods, Xcode DerivedData, yarn), but GitHub evicts caches unused for 7 days, and this workflow's runs have been more than 7 days apart (May 19 -> Jul 16 -> Jul 24). Every run therefore misses every cache. Once this SDK is triggered from the Bucketeer dev-deploy pipeline on every deployment (ca-dp/bucketeer-config), caches will stay warm and run times should drop substantially with no further changes.

### 2. The Android Gradle build runs inside the emulator step (fixed here)

`yarn build:e2e:android:reactX` (`expo run:android`) ran inside `android-emulator-runner`, so the 8-10 minute Gradle build competed for CPU with a running emulator on a 4-vCPU runner. The maestro flow starts with `launchApp` (appId `clientsdk.example`), so the emulator only needs the APK installed:

- **New step**: build the release APK with `./gradlew assembleRelease --build-cache` before the emulator boots (full CPU for Gradle, same `GRADLE_OPTS`)
- **Emulator step**: now only `adb install -r <apk> && maestro test e2e`
- Build failures are also now clearly separated from test failures in the UI

Also replaced the deprecated `gradle-home-cache-cleanup` input with `cache-cleanup: on-success` (flagged in run annotations).

Note: `.env` injection stays before the Gradle build since `EXPO_PUBLIC_*` vars are inlined when the JS bundle is built during `assembleRelease`. The release variant uses the debug signing config (RN/Expo template default, same as what `expo run:android --variant release` installed before), so `adb install` works unchanged.

## Test plan

- [x] Trigger the `E2e Tests` workflow (`workflow_dispatch`) on this branch and confirm both Android jobs pass
- [x] Confirm the new "Build demo app for Android" step succeeds and the emulator step drops to ~2-3 minutes
Results: https://github.com/bucketeer-io/react-native-client-sdk/actions/runs/30085126150
