### PR TITLE
ci: replace unmaintained maestro action and retry flaky iOS e2e run

### DIFF
--- a/.github/scripts/run-e2e-tests.sh
+++ b/.github/scripts/run-e2e-tests.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Runs the Maestro e2e suite, retrying once before failing: the demo app
+# occasionally crashes right after launchApp (transient RN startup flake).
+set -uo pipefail
+
+for attempt in 1 2; do
+  if maestro test e2e --format=junit --output=report.xml --no-ansi; then
+    exit 0
+  fi
+  echo "Maestro run failed (attempt $attempt)"
+done
+exit 1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,6 +24,7 @@ jobs:
       XCODE_VERSION: '26.0.1'
       # E2e - maestro framework is not working with iOS 26 simulators properly yet.
       IOS_DEVICE_ID: '8354E9A3-172D-4B54-A234-6369EAF61656' # iPhone 16 Pro - iOS 18.6
+      MAESTRO_VERSION: '2.0.10'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -163,18 +164,54 @@ jobs:
         run: |
           cp e2e/react_versions/react_${{ matrix.react-version }}.yml e2e/react_version.yml
 
-      - name: Run iOS E2E tests (React ${{ matrix.react-version }})
-        uses: dniHze/maestro-test-action@v1
+      # Install Maestro directly with the official installer instead of the
+      # unmaintained dniHze/maestro-test-action (Node 20 deprecation, and it
+      # installs idb_companion which Maestro 2.x no longer needs).
+      - name: Cache Maestro
+        id: maestro-cache
+        uses: actions/cache@v4
         with:
-          version: 2.0.10
-          flow: e2e
-          report: report.xml
+          path: |
+            ~/.maestro
+            !~/.maestro/tests
+          key: ${{ runner.os }}-maestro-${{ env.MAESTRO_VERSION }}
+
+      - name: Install Maestro
+        if: steps.maestro-cache.outputs.cache-hit != 'true'
+        run: curl -Ls "https://get.maestro.mobile.dev" | bash
+
+      - name: Add Maestro to PATH
+        run: echo "$HOME/.maestro/bin" >> $GITHUB_PATH
+
+      - name: Run iOS E2E tests (React ${{ matrix.react-version }})
+        run: |
+          # The demo app occasionally crashes right after launchApp on the
+          # simulator (transient RN startup flake); retry once before failing.
+          for attempt in 1 2; do
+            if maestro test e2e --format=junit --output=report.xml --no-ansi; then
+              exit 0
+            fi
+            echo "Maestro run failed (attempt $attempt)"
+          done
+          exit 1
 
       - name: Upload iOS E2E test results (React ${{ matrix.react-version }})
         uses: actions/upload-artifact@v4
         with:
           name: e2e-ios-react${{ matrix.react-version }}-results
           path: report.xml
+
+      # Simulator crash reports and Maestro debug logs, to diagnose the
+      # intermittent "App crashed or stopped while executing flow" failures.
+      - name: Upload crash diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-ios-react${{ matrix.react-version }}-crash-diagnostics
+          path: |
+            ~/Library/Logs/DiagnosticReports
+            ~/.maestro/tests
+          if-no-files-found: ignore
 
   build-android:
     name: Android E2E (React ${{ matrix.react-version }})
@@ -192,6 +229,8 @@ jobs:
           - 8
         react-version: [18, 19]
       fail-fast: true
+    env:
+      MAESTRO_VERSION: '2.0.10'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -307,10 +346,23 @@ jobs:
           disable-animations: true
           script: echo "Generated AVD snapshot for caching"
 
-      - name: Setup Maestro
-        uses: dniHze/maestro-test-action@v1
+      # Install Maestro directly with the official installer instead of the
+      # unmaintained dniHze/maestro-test-action (Node 20 deprecation).
+      - name: Cache Maestro
+        id: maestro-cache
+        uses: actions/cache@v4
         with:
-          version: 2.0.10
+          path: |
+            ~/.maestro
+            !~/.maestro/tests
+          key: ${{ runner.os }}-maestro-${{ env.MAESTRO_VERSION }}
+
+      - name: Install Maestro
+        if: steps.maestro-cache.outputs.cache-hit != 'true'
+        run: curl -Ls "https://get.maestro.mobile.dev" | bash
+
+      - name: Add Maestro to PATH
+        run: echo "$HOME/.maestro/bin" >> $GITHUB_PATH
 
       - name: Copy E2E test file for React ${{ matrix.react-version }}
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -183,17 +183,10 @@ jobs:
       - name: Add Maestro to PATH
         run: echo "$HOME/.maestro/bin" >> $GITHUB_PATH
 
+      # Runs with one retry: the demo app occasionally crashes right after
+      # launchApp on the simulator (transient RN startup flake).
       - name: Run iOS E2E tests (React ${{ matrix.react-version }})
-        run: |
-          # The demo app occasionally crashes right after launchApp on the
-          # simulator (transient RN startup flake); retry once before failing.
-          for attempt in 1 2; do
-            if maestro test e2e --format=junit --output=report.xml --no-ansi; then
-              exit 0
-            fi
-            echo "Maestro run failed (attempt $attempt)"
-          done
-          exit 1
+        run: ./.github/scripts/run-e2e-tests.sh
 
       - name: Upload iOS E2E test results (React ${{ matrix.react-version }})
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -368,6 +361,7 @@ jobs:
         run: |
           cp e2e/react_versions/react_${{ matrix.react-version }}.yml e2e/react_version.yml
 
+      # The test script runs maestro with one retry (transient app-startup crashes).
       - name: Run Android integration tests (React ${{ matrix.react-version }})
         uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed # v2.34.0
         with:
@@ -378,7 +372,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -memory 2048
           disable-animations: true
-          script: adb install -r demo/expo_react_${{ matrix.react-version }}/android/app/build/outputs/apk/release/app-release.apk && maestro test e2e --format=junit --output=report.xml --no-ansi
+          script: adb install -r demo/expo_react_${{ matrix.react-version }}/android/app/build/outputs/apk/release/app-release.apk && ./.github/scripts/run-e2e-tests.sh
 
       - name: Upload Android E2E test results (React ${{ matrix.react-version }})
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,4 @@
-name: E2e Tests
+name: E2E Tests
 on:
   push:
     branches:
@@ -43,7 +43,7 @@ jobs:
       # hit the whole build chain below is skipped.
       - name: Restore demo app cache
         id: app-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: build-artifacts/ios-react${{ matrix.react-version }}
           key: demo-app-ios-react${{ matrix.react-version }}-${{ hashFiles('src/**', 'package.json', 'yarn.lock', format('demo/expo_react_{0}/**', matrix.react-version), format('!demo/expo_react_{0}/node_modules/**', matrix.react-version), format('!demo/expo_react_{0}/android/**', matrix.react-version), format('!demo/expo_react_{0}/ios/**', matrix.react-version), format('demo/expo_react_{0}/.env', matrix.react-version)) }}-v1
@@ -90,7 +90,7 @@ jobs:
       - name: Restore CocoaPods cache
         if: steps.app-cache.outputs.cache-hit != 'true'
         id: cocoapods-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             demo/expo_react_${{ matrix.react-version }}/ios/Pods
@@ -107,7 +107,7 @@ jobs:
           pod install
           cd ../..
 
-      - uses: irgaly/xcode-cache@v1
+      - uses: irgaly/xcode-cache@4141f139f00e335c6e1031fb93e667181f86146f # v1.9.2
         if: steps.app-cache.outputs.cache-hit != 'true'
         with:
           key: xcode-cache-deriveddata-${{ github.workflow }}-react${{ matrix.react-version }}-${{ github.sha }}
@@ -134,7 +134,7 @@ jobs:
 
       - name: Cache cocoapods dependencies
         if: steps.app-cache.outputs.cache-hit != 'true' && steps.cocoapods-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             demo/expo_react_${{ matrix.react-version }}/ios/Pods
@@ -143,7 +143,7 @@ jobs:
 
       - name: Save demo app cache
         if: steps.app-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: build-artifacts/ios-react${{ matrix.react-version }}
           key: ${{ steps.app-cache.outputs.cache-primary-key }}
@@ -169,7 +169,7 @@ jobs:
       # installs idb_companion which Maestro 2.x no longer needs).
       - name: Cache Maestro
         id: maestro-cache
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.maestro
@@ -196,7 +196,7 @@ jobs:
           exit 1
 
       - name: Upload iOS E2E test results (React ${{ matrix.react-version }})
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-ios-react${{ matrix.react-version }}-results
           path: report.xml
@@ -205,7 +205,7 @@ jobs:
       # intermittent "App crashed or stopped while executing flow" failures.
       - name: Upload crash diagnostics
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-ios-react${{ matrix.react-version }}-crash-diagnostics
           path: |
@@ -222,7 +222,7 @@ jobs:
         api-level:
           - 34
         target:
-          - default  # Faster than google_apis
+          - default # Faster than google_apis
         arch:
           - x86_64
         cores:
@@ -233,7 +233,7 @@ jobs:
       MAESTRO_VERSION: '2.0.10'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Injected before the APK cache lookup so the cache key includes the
       # .env contents: rotating the e2e key/endpoint invalidates the cache.
@@ -249,7 +249,7 @@ jobs:
       # hit the whole build chain below is skipped.
       - name: Restore demo APK cache
         id: apk-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: demo/expo_react_${{ matrix.react-version }}/android/app/build/outputs/apk/release/app-release.apk
           key: demo-app-android-react${{ matrix.react-version }}-${{ hashFiles('src/**', 'package.json', 'yarn.lock', format('demo/expo_react_{0}/**', matrix.react-version), format('!demo/expo_react_{0}/node_modules/**', matrix.react-version), format('!demo/expo_react_{0}/android/**', matrix.react-version), format('!demo/expo_react_{0}/ios/**', matrix.react-version), format('demo/expo_react_{0}/.env', matrix.react-version)) }}-v1
@@ -273,7 +273,7 @@ jobs:
         if: steps.apk-cache.outputs.cache-hit != 'true'
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
-          distribution: "temurin"
+          distribution: 'temurin'
           java-version: 17
 
       - name: Setup gradle
@@ -285,7 +285,7 @@ jobs:
           cache-cleanup: on-success
           cache-read-only: false
         env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2  # Reduce timeout from default 5 minutes
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2 # Reduce timeout from default 5 minutes
           GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: true
 
       # Retry gradle setup if it failed (usually due to cache timeout)
@@ -294,7 +294,7 @@ jobs:
         uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
         with:
           cache-read-only: false
-          cache-disabled: true  # Disable cache on retry to avoid timeout
+          cache-disabled: true # Disable cache on retry to avoid timeout
 
       # Build the APK before booting the emulator so Gradle gets the full CPU.
       # The maestro flow launches the app itself (launchApp), so the emulator
@@ -310,7 +310,7 @@ jobs:
 
       - name: Save demo APK cache
         if: steps.apk-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: demo/expo_react_${{ matrix.react-version }}/android/app/build/outputs/apk/release/app-release.apk
           key: ${{ steps.apk-cache.outputs.cache-primary-key }}
@@ -350,7 +350,7 @@ jobs:
       # unmaintained dniHze/maestro-test-action (Node 20 deprecation).
       - name: Cache Maestro
         id: maestro-cache
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.maestro
@@ -381,7 +381,7 @@ jobs:
           script: adb install -r demo/expo_react_${{ matrix.react-version }}/android/app/build/outputs/apk/release/app-release.apk && maestro test e2e --format=junit --output=report.xml --no-ansi
 
       - name: Upload Android E2E test results (React ${{ matrix.react-version }})
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-android-react${{ matrix.react-version }}-results
           path: report.xml


### PR DESCRIPTION
## Summary

The iOS e2e job fails intermittently with "App crashed or stopped while executing flow" during the `evaluations` flow ([example run](https://github.com/bucketeer-io/react-native-client-sdk/actions/runs/30534288578/job/90843711452)). The log shows Maestro itself working fine — the `react_version` flow passes, then the app dies ~3s after `launchApp` relaunches it, a transient React Native startup crash on the simulator rather than a tooling problem.

## Changes

- Replace the unmaintained `dniHze/maestro-test-action@v1` with the official Maestro installer (`get.maestro.mobile.dev`), pinned to 2.0.10 via `MAESTRO_VERSION` and cached. This removes the Node 20 deprecation warning and skips the `idb_companion` install, which Maestro 2.x no longer needs.
- Retry the iOS Maestro run once before failing the job, since the crash is transient.
- On failure, upload `~/Library/Logs/DiagnosticReports` and Maestro's debug output as artifacts so we can see the actual crash reason if it persists.

## Test plan

- [x] Trigger the e2e workflow and confirm both iOS and Android jobs pass
- [x] Confirm the Node 20 deprecation warning for the maestro action is gone
https://github.com/bucketeer-io/react-native-client-sdk/actions/runs/30536694283